### PR TITLE
Implement a simple To-Do list

### DIFF
--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -22,27 +22,31 @@ impl SimpleComponent for ContentModel {
     type Output = ();
 
     view! {
-        gtk::Box {
-            set_orientation: gtk::Orientation::Vertical,
-            set_margin_all: 12,
-            set_spacing: 12,
+        gtk::ScrolledWindow {
+            set_vexpand: true,
 
-            gtk::Entry {
-                set_placeholder_text: Some("Enter a Task..."),
+            gtk::Box {
+                set_orientation: gtk::Orientation::Vertical,
+                set_margin_all: 12,
+                set_spacing: 12,
 
-                connect_activate[sender] => move |entry| {
-                    sender.input(Self::Input::AddTask(entry.text().to_string()));
-                    sender.input(Self::Input::ClearBuffer(entry.buffer()));
+                gtk::Entry {
+                    set_placeholder_text: Some("Enter a Task..."),
+
+                    connect_activate[sender] => move |entry| {
+                        sender.input(Self::Input::AddTask(entry.text().to_string()));
+                        sender.input(Self::Input::ClearBuffer(entry.buffer()));
+                    },
                 },
-            },
 
-            #[local_ref]
-            task_list_box -> gtk::ListBox {
-                set_css_classes: &["boxed-list"],
+                #[local_ref]
+                task_list_box -> gtk::ListBox {
+                    set_css_classes: &["boxed-list"],
 
-                #[watch]
-                set_visible: !model.tasks.is_empty(),
-            },
+                    #[watch]
+                    set_visible: !model.tasks.is_empty(),
+                },
+            }
         },
     }
 

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -4,7 +4,10 @@ use gtk::prelude::*;
 pub(crate) struct ContentModel;
 
 #[derive(Debug)]
-pub(crate) enum ContentInput {}
+pub(crate) enum ContentInput {
+    AddTask(String),
+    ClearBuffer(gtk::EntryBuffer),
+}
 
 #[relm4::component(pub(crate))]
 impl SimpleComponent for ContentModel {
@@ -14,18 +17,25 @@ impl SimpleComponent for ContentModel {
     type Output = ();
 
     view! {
-        gtk::Label {
-            set_label: "Hello, World!",
-            set_margin_all: 4,
-            set_css_classes: &["title-1"],
-            set_vexpand: true,
+        gtk::Box {
+            set_orientation: gtk::Orientation::Vertical,
+            set_margin_all: 12,
+
+            gtk::Entry {
+                set_placeholder_text: Some("Enter a Task..."),
+
+                connect_activate[sender] => move |entry| {
+                    sender.input(Self::Input::AddTask(entry.text().to_string()));
+                    sender.input(Self::Input::ClearBuffer(entry.buffer()));
+                },
+            },
         },
     }
 
     fn init(
         _init: Self::Init,
         root: &Self::Root,
-        _sender: ComponentSender<Self>,
+        sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         let model = ContentModel;
 
@@ -35,6 +45,10 @@ impl SimpleComponent for ContentModel {
     }
 
     fn update(&mut self, message: Self::Input, _sender: ComponentSender<Self>) {
-        match message {}
+        match message {
+            Self::Input::AddTask(text) if text.is_empty() => (),
+            Self::Input::AddTask(text) => println!("{text:?}"),  // TODO: Implement actual action
+            Self::Input::ClearBuffer(buffer) => buffer.set_text(""),
+        }
     }
 }

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -1,7 +1,12 @@
-use relm4::prelude::*;
 use gtk::prelude::*;
+use relm4::factory::FactoryVecDeque;
+use relm4::prelude::*;
 
-pub(crate) struct ContentModel;
+mod task;
+
+pub(crate) struct ContentModel {
+    tasks: FactoryVecDeque<task::Task>,
+}
 
 #[derive(Debug)]
 pub(crate) enum ContentInput {
@@ -20,6 +25,7 @@ impl SimpleComponent for ContentModel {
         gtk::Box {
             set_orientation: gtk::Orientation::Vertical,
             set_margin_all: 12,
+            set_spacing: 12,
 
             gtk::Entry {
                 set_placeholder_text: Some("Enter a Task..."),
@@ -29,6 +35,14 @@ impl SimpleComponent for ContentModel {
                     sender.input(Self::Input::ClearBuffer(entry.buffer()));
                 },
             },
+
+            #[local_ref]
+            task_list_box -> gtk::ListBox {
+                set_css_classes: &["boxed-list"],
+
+                #[watch]
+                set_visible: !model.tasks.is_empty(),
+            },
         },
     }
 
@@ -37,8 +51,10 @@ impl SimpleComponent for ContentModel {
         root: &Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
-        let model = ContentModel;
+        let tasks = FactoryVecDeque::new(gtk::ListBox::default(), sender.input_sender());
+        let model = ContentModel { tasks };
 
+        let task_list_box = model.tasks.widget();
         let widgets = view_output!();
 
         ComponentParts { model, widgets }
@@ -47,7 +63,9 @@ impl SimpleComponent for ContentModel {
     fn update(&mut self, message: Self::Input, _sender: ComponentSender<Self>) {
         match message {
             Self::Input::AddTask(text) if text.is_empty() => (),
-            Self::Input::AddTask(text) => println!("{text:?}"),  // TODO: Implement actual action
+            Self::Input::AddTask(text) => {
+                self.tasks.guard().push_front(text);
+            }
             Self::Input::ClearBuffer(buffer) => buffer.set_text(""),
         }
     }

--- a/src/app/content/task.rs
+++ b/src/app/content/task.rs
@@ -1,0 +1,40 @@
+use super::ContentInput;
+
+use gtk::prelude::*;
+use relm4::prelude::*;
+
+pub(crate) struct Task(String);
+
+#[relm4::factory(pub(crate))]
+impl FactoryComponent for Task {
+    type Init = String;
+
+    type Input = ();
+    type Output = ();
+
+    type CommandOutput = ();
+    type ParentInput = ContentInput;
+    type ParentWidget = gtk::ListBox;
+
+    view! {
+        gtk::CheckButton {
+            set_label: Some(self.0.as_str()),
+            set_halign: gtk::Align::Start,
+            set_margin_all: 8,
+        }
+    }
+
+    fn forward_to_parent(_output: Self::Output) -> Option<Self::ParentInput> {
+        None
+    }
+
+    fn init_model(
+        description: Self::Init,
+        _index: &DynamicIndex,
+        _sender: FactorySender<Self>,
+    ) -> Self {
+        Self(description)
+    }
+
+    fn update(&mut self, _input: Self::Input, _sender: FactorySender<Self>) {}
+}


### PR DESCRIPTION
Here's a simple To-Do list, pretty bare bones.

The list is volatile, meaning it forgets every item in it and start blank the next time.

You can't delete tasks; you have to restart the app and type the correct tasks.

You can check and uncheck items.

![Screenshot from 2023-10-03 13-47-02](https://github.com/tiago-vargas/simple-relm4-todo-app/assets/78927143/761606d7-016b-4f03-9f31-50003490956f)

![Screenshot from 2023-10-03 13-47-43](https://github.com/tiago-vargas/simple-relm4-todo-app/assets/78927143/8e28f1d3-9902-472d-8d42-24a251db09a2)

I made the newest items appear close to the text entry, because that makes easier to see that new items are actually added, instead of having to scroll down every time the list is too long
That's why the order is reversed.

Also, you can't add tasks without descriptions!