### PR TITLE
Implement persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,6 +552,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +851,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,6 +889,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,6 +914,7 @@ version = "0.1.0"
 dependencies = [
  "relm4",
  "relm4-components",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,6 +914,7 @@ version = "0.1.0"
 dependencies = [
  "relm4",
  "relm4-components",
+ "serde",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2021"
 [dependencies]
 relm4 = { version = "0.6.2", features = ["libadwaita"] }
 relm4-components = "0.6.2"
+serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 relm4 = { version = "0.6.2", features = ["libadwaita"] }
 relm4-components = "0.6.2"
+serde_json = "1.0.107"

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,8 @@ use relm4::prelude::*;
 
 mod content;
 
+pub(crate) const APP_ID: &str = "com.github.tiago-vargas.simple-relm4-todo";
+
 pub(crate) struct AppModel {
     content: Controller<content::ContentModel>,
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@ use relm4::prelude::*;
 use std::fs;
 
 mod content;
+mod task;
 
 pub(crate) const APP_ID: &str = "com.github.tiago-vargas.simple-relm4-todo";
 pub(crate) const FILE_NAME: &str = "data.json";
@@ -70,7 +71,7 @@ impl SimpleComponent for AppModel {
         match message {
             Self::Input::SaveTasks => {
                 let content_model = self.content.model();
-                let tasks: Vec<&content::task::Task> = content_model.tasks
+                let tasks: Vec<&task::Task> = content_model.tasks
                     .iter()
                     .map(|row| &row.task)
                     .collect();
@@ -93,7 +94,7 @@ impl SimpleComponent for AppModel {
                 path.push(FILE_NAME);
 
                 if let Ok(file) = fs::File::open(path) {
-                    let tasks: Vec<content::task::Task> = serde_json::from_reader(file)
+                    let tasks: Vec<task::Task> = serde_json::from_reader(file)
                         .expect("Could not read data from JSON file.");
 
                     self.content.sender().send(content::ContentInput::RestoreTasks(tasks))

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -2,10 +2,10 @@ use gtk::prelude::*;
 use relm4::factory::FactoryVecDeque;
 use relm4::prelude::*;
 
-mod task;
+pub(crate) mod task;
 
 pub(crate) struct ContentModel {
-    tasks: FactoryVecDeque<task::TaskRow>,
+    pub(crate) tasks: FactoryVecDeque<task::TaskRow>,
 }
 
 #[derive(Debug)]
@@ -36,6 +36,7 @@ impl SimpleComponent for ContentModel {
                     connect_activate[sender] => move |entry| {
                         let task = task::Task {
                             description: entry.text().to_string(),
+                            completed: false,
                         };
                         sender.input(Self::Input::AddTask(task));
                         sender.input(Self::Input::ClearBuffer(entry.buffer()));

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -10,7 +10,7 @@ pub(crate) struct ContentModel {
 
 #[derive(Debug)]
 pub(crate) enum ContentInput {
-    AddTask(String),
+    AddTask(task::Task),
     ClearBuffer(gtk::EntryBuffer),
 }
 
@@ -34,7 +34,10 @@ impl SimpleComponent for ContentModel {
                     set_placeholder_text: Some("Enter a Task..."),
 
                     connect_activate[sender] => move |entry| {
-                        sender.input(Self::Input::AddTask(entry.text().to_string()));
+                        let task = task::Task {
+                            description: entry.text().to_string(),
+                        };
+                        sender.input(Self::Input::AddTask(task));
                         sender.input(Self::Input::ClearBuffer(entry.buffer()));
                     },
                 },
@@ -66,9 +69,9 @@ impl SimpleComponent for ContentModel {
 
     fn update(&mut self, message: Self::Input, _sender: ComponentSender<Self>) {
         match message {
-            Self::Input::AddTask(text) if text.is_empty() => (),
-            Self::Input::AddTask(text) => {
-                self.tasks.guard().push_front(text);
+            Self::Input::AddTask(t) if t.description.is_empty() => (),
+            Self::Input::AddTask(t) => {
+                self.tasks.guard().push_front(t);
             }
             Self::Input::ClearBuffer(buffer) => buffer.set_text(""),
         }

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -2,7 +2,7 @@ use gtk::prelude::*;
 use relm4::factory::FactoryVecDeque;
 use relm4::prelude::*;
 
-pub(crate) mod task;
+use crate::app::task;
 
 pub(crate) struct ContentModel {
     pub(crate) tasks: FactoryVecDeque<task::TaskRow>,

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -5,7 +5,7 @@ use relm4::prelude::*;
 mod task;
 
 pub(crate) struct ContentModel {
-    tasks: FactoryVecDeque<task::Task>,
+    tasks: FactoryVecDeque<task::TaskRow>,
 }
 
 #[derive(Debug)]

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -11,6 +11,7 @@ pub(crate) struct ContentModel {
 #[derive(Debug)]
 pub(crate) enum ContentInput {
     AddTask(task::Task),
+    RestoreTasks(Vec<task::Task>),
     ClearBuffer(gtk::EntryBuffer),
 }
 
@@ -73,6 +74,11 @@ impl SimpleComponent for ContentModel {
             Self::Input::AddTask(t) if t.description.is_empty() => (),
             Self::Input::AddTask(t) => {
                 self.tasks.guard().push_front(t);
+            }
+            Self::Input::RestoreTasks(tasks) => {
+                for t in tasks {
+                    self.tasks.guard().push_back(t);
+                }
             }
             Self::Input::ClearBuffer(buffer) => buffer.set_text(""),
         }

--- a/src/app/content/task.rs
+++ b/src/app/content/task.rs
@@ -3,20 +3,28 @@ use super::ContentInput;
 use gtk::prelude::*;
 use relm4::prelude::*;
 
+use serde::Serialize;
+
 pub(crate) struct TaskRow {
     pub(crate) task: Task,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub(crate) struct Task {
     pub(crate) description: String,
+    pub(crate) completed: bool,
+}
+
+#[derive(Debug)]
+pub(crate) enum TaskRowInput {
+    Toggle,
 }
 
 #[relm4::factory(pub(crate))]
 impl FactoryComponent for TaskRow {
     type Init = Task;
 
-    type Input = ();
+    type Input = TaskRowInput;
     type Output = ();
 
     type CommandOutput = ();
@@ -27,7 +35,12 @@ impl FactoryComponent for TaskRow {
         gtk::CheckButton {
             set_label: Some(self.task.description.as_str()),
             set_halign: gtk::Align::Start,
+            set_active: self.task.completed,
             set_margin_all: 8,
+
+            connect_toggled[sender] => move |_| {
+                sender.input(Self::Input::Toggle)
+            },
         }
     }
 
@@ -43,5 +56,11 @@ impl FactoryComponent for TaskRow {
         Self { task }
     }
 
-    fn update(&mut self, _input: Self::Input, _sender: FactorySender<Self>) {}
+    fn update(&mut self, input: Self::Input, _sender: FactorySender<Self>) {
+        match input {
+            Self::Input::Toggle => {
+                self.task.completed = !self.task.completed;
+            }
+        }
+    }
 }

--- a/src/app/content/task.rs
+++ b/src/app/content/task.rs
@@ -3,11 +3,18 @@ use super::ContentInput;
 use gtk::prelude::*;
 use relm4::prelude::*;
 
-pub(crate) struct TaskRow(String);
+pub(crate) struct TaskRow {
+    pub(crate) task: Task,
+}
+
+#[derive(Debug)]
+pub(crate) struct Task {
+    pub(crate) description: String,
+}
 
 #[relm4::factory(pub(crate))]
 impl FactoryComponent for TaskRow {
-    type Init = String;
+    type Init = Task;
 
     type Input = ();
     type Output = ();
@@ -18,7 +25,7 @@ impl FactoryComponent for TaskRow {
 
     view! {
         gtk::CheckButton {
-            set_label: Some(self.0.as_str()),
+            set_label: Some(self.task.description.as_str()),
             set_halign: gtk::Align::Start,
             set_margin_all: 8,
         }
@@ -29,11 +36,11 @@ impl FactoryComponent for TaskRow {
     }
 
     fn init_model(
-        description: Self::Init,
+        task: Self::Init,
         _index: &DynamicIndex,
         _sender: FactorySender<Self>,
     ) -> Self {
-        Self(description)
+        Self { task }
     }
 
     fn update(&mut self, _input: Self::Input, _sender: FactorySender<Self>) {}

--- a/src/app/content/task.rs
+++ b/src/app/content/task.rs
@@ -3,13 +3,13 @@ use super::ContentInput;
 use gtk::prelude::*;
 use relm4::prelude::*;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 pub(crate) struct TaskRow {
     pub(crate) task: Task,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct Task {
     pub(crate) description: String,
     pub(crate) completed: bool,

--- a/src/app/content/task.rs
+++ b/src/app/content/task.rs
@@ -3,10 +3,10 @@ use super::ContentInput;
 use gtk::prelude::*;
 use relm4::prelude::*;
 
-pub(crate) struct Task(String);
+pub(crate) struct TaskRow(String);
 
 #[relm4::factory(pub(crate))]
-impl FactoryComponent for Task {
+impl FactoryComponent for TaskRow {
     type Init = String;
 
     type Input = ();

--- a/src/app/task.rs
+++ b/src/app/task.rs
@@ -1,4 +1,4 @@
-use super::ContentInput;
+use super::content::ContentInput;
 
 use gtk::prelude::*;
 use relm4::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,6 @@ use relm4::prelude::*;
 mod app;
 
 fn main() {
-    let app = RelmApp::new("com.github.tiago-vargas.simple-relm4-todo");
+    let app = RelmApp::new(app::APP_ID);
     app.run::<app::AppModel>(());
 }


### PR DESCRIPTION
The app now **saves** current tasks when closing and **loads** them when launching.

Tasks are saved as JSON under `~/.local/share/com.github.tiago-vargas.simple-relm4-todo` as `data.json`.

In order to implement this, I had to add to add the crate `serde_json` and the crate `serde` with the `derive` feature.
The `derive` feature was needed for the `Task` structure to be (de)serializable.

One thing to note is that the serialized `Task` is another structure.
The previous `Task` was renamed to `TaskRow` in order to make it more explicit that it's supposed to be a component.
The contents of this `TaskRow` is the `Task` that's (de)serialized.

I moved the module `task` to be a child of `app`, instead of `app::content` as it makes more sense for the app itself to handle save and load of tasks.
The content still populates the view with tasks.

I also extracted the app ID as a constant.
It was useful when creating the JSON file path.