### PR TITLE
Remove tasks

### DIFF
--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -11,6 +11,7 @@ pub(crate) struct ContentModel {
 #[derive(Debug)]
 pub(crate) enum ContentInput {
     AddTask(task::Task),
+    RemoveTask(DynamicIndex),
     RestoreTasks(Vec<task::Task>),
     ClearBuffer(gtk::EntryBuffer),
 }
@@ -74,6 +75,9 @@ impl SimpleComponent for ContentModel {
             Self::Input::AddTask(t) if t.description.is_empty() => (),
             Self::Input::AddTask(t) => {
                 self.tasks.guard().push_front(t);
+            }
+            Self::Input::RemoveTask(index) => {
+                _ = self.tasks.guard().remove(index.current_index());
             }
             Self::Input::RestoreTasks(tasks) => {
                 for t in tasks {

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -74,14 +74,14 @@ impl SimpleComponent for ContentModel {
         match message {
             Self::Input::AddTask(t) if t.description.is_empty() => (),
             Self::Input::AddTask(t) => {
-                self.tasks.guard().push_front(t);
+                _ = self.tasks.guard().push_front(t);
             }
             Self::Input::RemoveTask(index) => {
                 _ = self.tasks.guard().remove(index.current_index());
             }
             Self::Input::RestoreTasks(tasks) => {
                 for t in tasks {
-                    self.tasks.guard().push_back(t);
+                    _ = self.tasks.guard().push_back(t);
                 }
             }
             Self::Input::ClearBuffer(buffer) => buffer.set_text(""),

--- a/src/app/task.rs
+++ b/src/app/task.rs
@@ -32,14 +32,30 @@ impl FactoryComponent for TaskRow {
     type ParentWidget = gtk::ListBox;
 
     view! {
-        gtk::CheckButton {
-            set_label: Some(self.task.description.as_str()),
-            set_halign: gtk::Align::Start,
-            set_active: self.task.completed,
-            set_margin_all: 8,
+        gtk::Box {
+            set_orientation: gtk::Orientation::Horizontal,
+            set_spacing: 8,
 
-            connect_toggled[sender] => move |_| {
-                sender.input(Self::Input::Toggle)
+            gtk::CheckButton {
+                set_label: Some(self.task.description.as_str()),
+                set_halign: gtk::Align::Start,
+                set_active: self.task.completed,
+                set_hexpand: true,
+                set_margin_all: 8,
+
+                connect_toggled[sender] => move |_| {
+                    sender.input(Self::Input::Toggle)
+                },
+            },
+
+            gtk::Button {
+                set_icon_name: "edit-delete-symbolic",
+                set_css_classes: &["destructive-action"],
+                set_margin_all: 8,
+
+                connect_clicked[sender] => move |_| {
+                    // TODO: Add action to remove this task
+                },
             },
         }
     }

--- a/src/app/task.rs
+++ b/src/app/task.rs
@@ -20,12 +20,17 @@ pub(crate) enum TaskRowInput {
     Toggle,
 }
 
+#[derive(Debug)]
+pub(crate) enum TaskRowOutput {
+    Remove(DynamicIndex),
+}
+
 #[relm4::factory(pub(crate))]
 impl FactoryComponent for TaskRow {
     type Init = Task;
 
     type Input = TaskRowInput;
-    type Output = ();
+    type Output = TaskRowOutput;
 
     type CommandOutput = ();
     type ParentInput = ContentInput;
@@ -53,15 +58,17 @@ impl FactoryComponent for TaskRow {
                 set_css_classes: &["destructive-action"],
                 set_margin_all: 8,
 
-                connect_clicked[sender] => move |_| {
-                    // TODO: Add action to remove this task
+                connect_clicked[sender, index] => move |_| {
+                    sender.output(Self::Output::Remove(index.clone()));
                 },
             },
         }
     }
 
-    fn forward_to_parent(_output: Self::Output) -> Option<Self::ParentInput> {
-        None
+    fn forward_to_parent(output: Self::Output) -> Option<Self::ParentInput> {
+        Some(match output {
+            Self::Output::Remove(index) => ContentInput::RemoveTask(index),
+        })
     }
 
     fn init_model(


### PR DESCRIPTION
I added a button to remove a task from the list.

[Screencast from 2023-10-13 13-30-41.webm](https://github.com/tiago-vargas/simple-relm4-todo-app/assets/78927143/65cee208-a3a9-4c59-89d9-a7b426c207c2)

One **problem** is when a task description is longer the the window.
The button will be "hidden", because the window will clip it:

[Screencast from 2023-10-13 13-28-54.webm](https://github.com/tiago-vargas/simple-relm4-todo-app/assets/78927143/c51b8ace-d57d-42f2-adbb-aa1a6f5ae65c)

As a note, I also assigned to `_` functions whose return values weren't being used.
For example, for a function `f` that returns a value, I changed `f();` to `_ = f();` to make it explicit that I know about its return value and I deliberately chose not to use it.
This should make it easier in the future to think about other approaches that may end up using the return values of these functions, because they're now "marked" with this assignment.