### PR TITLE
Change app ID

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -6,7 +6,7 @@ use std::fs;
 mod content;
 mod task;
 
-pub(crate) const APP_ID: &str = "com.github.tiago-vargas.simple-relm4-todo";
+pub(crate) const APP_ID: &str = "com.github.tiago_vargas.simple_relm4_todo";
 pub(crate) const FILE_NAME: &str = "data.json";
 
 pub(crate) struct AppModel {


### PR DESCRIPTION
Replaces dashes with underscores to avoid issues where it isn't allowed, such as Flatpak app IDs.

This won't conflict with other GitHub user, as underscores are not allowed in usernames.