### PR TITLE
Preserve window size

### DIFF
--- a/data/com.github.tiago_vargas.simple_relm4_todo.gschema.xml
+++ b/data/com.github.tiago_vargas.simple_relm4_todo.gschema.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<schemalist>
+	<schema id="com.github.tiago_vargas.simple_relm4_todo"
+	        path="/com/github/tiago_vargas/simple_relm4_todo/">
+		<key name="window-width" type="i">
+			<default>400</default>
+			<summary>Default window width</summary>
+		</key>
+		<key name="window-height" type="i">
+			<default>500</default>
+			<summary>Default window height</summary>
+		</key>
+		<key name="window-is-maximized" type="b">
+			<default>false</default>
+			<summary>Default window maximized behaviour</summary>
+		</key>
+	</schema>
+</schemalist>

--- a/src/app.rs
+++ b/src/app.rs
@@ -65,11 +65,11 @@ impl SimpleComponent for AppModel {
             },
 
             connect_show[sender] => move |_| {
-                sender.input(AppInput::LoadTasks);
+                sender.input(Self::Input::LoadTasks);
             },
 
             connect_close_request[sender, window] => move |_| {
-                sender.input(AppInput::SaveTasks);
+                sender.input(Self::Input::SaveTasks);
                 if window.is_maximized() {
                     sender.input(Self::Input::SaveWindowSize(WindowSize::Maximized));
                 } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,6 +17,21 @@ pub(crate) struct AppModel {
 pub(crate) enum AppInput {
     SaveTasks,
     LoadTasks,
+    SaveWindowSize(i32, i32),
+}
+
+enum Settings {
+    WindowWidth,
+    WindowHeight,
+}
+
+impl Settings {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::WindowWidth => "window-width",
+            Self::WindowHeight => "window-height",
+        }
+    }
 }
 
 #[relm4::component(pub(crate))]
@@ -29,8 +44,8 @@ impl SimpleComponent for AppModel {
     view! {
         adw::ApplicationWindow {
             set_title: Some("To-Do"),
-            set_default_width: 400,
-            set_default_height: 500,
+            set_default_width: settings.int(Settings::WindowWidth.as_str()),
+            set_default_height: settings.int(Settings::WindowHeight.as_str()),
 
             gtk::Box {
                 set_orientation: gtk::Orientation::Vertical,
@@ -44,8 +59,11 @@ impl SimpleComponent for AppModel {
                 sender.input(AppInput::LoadTasks);
             },
 
-            connect_close_request[sender] => move |_| {
+            connect_close_request[sender, window] => move |_| {
                 sender.input(AppInput::SaveTasks);
+                let width = window.width();
+                let height = window.height();
+                sender.input(Self::Input::SaveWindowSize(width, height));
                 gtk::Inhibit(false)
             },
         }
@@ -57,6 +75,8 @@ impl SimpleComponent for AppModel {
         window: &Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
+        let settings = gtk::gio::Settings::new(APP_ID);
+
         let content = content::ContentModel::builder()
             .launch(())
             .detach();
@@ -100,6 +120,11 @@ impl SimpleComponent for AppModel {
                     self.content.sender().send(content::ContentInput::RestoreTasks(tasks))
                         .expect("Could not send message to child component.");
                 }
+            }
+            Self::Input::SaveWindowSize(width, height) => {
+                let settings = gtk::gio::Settings::new(APP_ID);
+                _ = settings.set_int(Settings::WindowWidth.as_str(), width);
+                _ = settings.set_int(Settings::WindowHeight.as_str(), height);
             }
         }
     }


### PR DESCRIPTION
The app will save the window size on close and restore it on next launch.
It will also launch maximized if it was closed maximized.

To do this, I added a GSchema file, which should be compiled in the user's `~/.local/share/glib-2.0/` directory.

I also refactored a bit, replacing `AppInput` with `Self::Input` to make the code consistent.