### PR TITLE
Prevent entry row from scrolling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,6 +912,7 @@ dependencies = [
 name = "simple-relm4-todo"
 version = "0.1.0"
 dependencies = [
+ "libadwaita",
  "relm4",
  "relm4-components",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+libadwaita = { version = "=0.4.4", features = ["v1_4"] }
 relm4 = { version = "0.6.2", features = ["libadwaita"] }
 relm4-components = "0.6.2"
 serde = { version = "1.0.188", features = ["derive"] }

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -15,7 +15,6 @@ pub(crate) enum ContentInput {
     MoveTaskUp(DynamicIndex),
     MoveTaskDown(DynamicIndex),
     RestoreTasks(Vec<task::Task>),
-    ClearBuffer(gtk::EntryBuffer),
 }
 
 #[relm4::component(pub(crate))]
@@ -32,20 +31,6 @@ impl SimpleComponent for ContentModel {
             gtk::Box {
                 set_orientation: gtk::Orientation::Vertical,
                 set_margin_all: 12,
-                set_spacing: 12,
-
-                gtk::Entry {
-                    set_placeholder_text: Some("Enter a Task..."),
-
-                    connect_activate[sender] => move |entry| {
-                        let task = task::Task {
-                            description: entry.text().to_string(),
-                            completed: false,
-                        };
-                        sender.input(Self::Input::AddTask(task));
-                        sender.input(Self::Input::ClearBuffer(entry.buffer()));
-                    },
-                },
 
                 #[local_ref]
                 task_list_box -> gtk::ListBox {
@@ -54,8 +39,8 @@ impl SimpleComponent for ContentModel {
                     #[watch]
                     set_visible: !model.tasks.is_empty(),
                 },
-            }
-        },
+            },
+        }
     }
 
     fn init(
@@ -102,7 +87,6 @@ impl SimpleComponent for ContentModel {
                     _ = self.tasks.guard().push_back(t);
                 }
             }
-            Self::Input::ClearBuffer(buffer) => buffer.set_text(""),
         }
     }
 }


### PR DESCRIPTION
I moved the entry row to an `ToolbarView`, so it will now always stay at the top:

[Screencast from 2023-12-03 12-01-11.webm](https://github.com/tiago-vargas/simple-relm4-todo-app/assets/78927143/b446b6ea-0740-45d6-877c-a6761d760a33)

I set the `libadwaita` crate to use the feature `v1_4` for this to work.

I had to move some input messages from `content` to `app`, because the entry row is now there.
It needed to be at the same level of the header bar, so they could be on the same `ToolbarView`.