### PR TITLE
Place entry row at the bottom

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -36,12 +36,13 @@ impl SimpleComponent for AppModel {
 
             adw::ToolbarView {
                 add_top_bar = &adw::HeaderBar,
-                add_top_bar = &gtk::Entry {
+
+                #[wrap(Some)]
+                set_content = model.content.widget(),
+
+                add_bottom_bar = &gtk::Entry {
                     set_placeholder_text: Some("Enter a Task..."),
-                    set_margin_start: 8,
-                    set_margin_end: 8,
-                    set_margin_top: 4,
-                    set_margin_bottom: 4,
+                    set_margin_all: 8,
 
                     connect_activate[sender] => move |entry| {
                         let task = task::Task {
@@ -52,9 +53,6 @@ impl SimpleComponent for AppModel {
                         sender.input(Self::Input::ClearBuffer(entry.buffer()));
                     },
                 },
-
-                #[wrap(Some)]
-                set_content = model.content.widget(),
             },
 
             connect_show[sender] => move |_| {

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -61,7 +61,7 @@ impl SimpleComponent for ContentModel {
         match message {
             Self::Input::AddTask(t) if t.description.is_empty() => (),
             Self::Input::AddTask(t) => {
-                _ = self.tasks.guard().push_front(t);
+                _ = self.tasks.guard().push_back(t);
             }
             Self::Input::RemoveTask(index) => {
                 _ = self.tasks.guard().remove(index.current_index());


### PR DESCRIPTION
The entry row will now be at the bottom.
See #21 for context.

[Screencast from 2023-12-03 13-46-24.webm](https://github.com/tiago-vargas/simple-relm4-todo-app/assets/78927143/e94ba401-3356-4a7e-b88b-03d0c49e3330)

Note that I made new tasks appear at the bottom of the list, instead of at the top.
That's because it's more intuitive to me for tasks to appear near the entry row.
They were being added at the top because that's where the entry row was in the first place.

See #4:

> I made the newest items appear close to the text entry, because that makes easier to see that new items are actually added, instead of having to scroll down every time the list is too long
That's why the order is reversed.

The idea was for the bottom bar to also mimic a task row you're about to write in the bottom of the list, but more work should be put on that, as it's currently not very similar.